### PR TITLE
Add missing keys to service account

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -18,6 +18,7 @@
 		},
 		"service": {
 			"address": "f8d6e0586b0a20c7",
+            "keys": "67ff105cfed60b0db9f95960851b9b96a73a03e972a09195a0efa709a828958b",
 			"privateKey": "67ff105cfed60b0db9f95960851b9b96a73a03e972a09195a0efa709a828958b",
 			"sigAlgorithm": "ECDSA_P256",
 			"hashAlgorithm": "SHA3_256"


### PR DESCRIPTION
It throws an error "invalid project configuration: input has incorrect ECDSA_P256 key size" after the command "flow emulator start". Adding the "keys" definition to the service account solves the problem.